### PR TITLE
chore(release): bump plugin for index-converter 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@adobe/aio-cli-plugin-aem-cloud-service-migration",
     "description": "AEM Cloud Service Migration commands for the Adobe I/O CLI",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "repository": "adobe/aio-cli-plugin-aem-cloud-service-migration",
     "author": "Adobe Inc.",
     "license": "Apache-2.0",
@@ -16,7 +16,7 @@
         "@adobe/aem-cs-source-migration-dispatcher-converter": "^1.5.2",
         "@adobe/aem-cs-source-migration-commons": "^0.0.6",
         "@adobe/aem-cs-source-migration-repository-modernizer": "^1.2.3",
-        "@adobe/aem-cs-source-migration-index-converter": "^0.2.2",
+        "@adobe/aem-cs-source-migration-index-converter": "^0.2.3",
         "@oclif/command": "^1.6.1",
         "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.1.2",


### PR DESCRIPTION
Increase @adobe/aio-cli-plugin-aem-cloud-service-migration to 1.3.1 and update the index-converter dependency to ^0.2.3 so the CLI plugin picks up the released crash fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
